### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for Google Cloud services including Logging, Spanner, Monitoring, and Cloud Trace.
 
+<a href="https://glama.ai/mcp/servers/@andyl25/googlecloud-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@andyl25/googlecloud-mcp/badge" alt="Google Cloud Server MCP server" />
+</a>
+
 ## Features
 
 - **Google Cloud Logging**: Query logs, list log entries, and search across different log sources
@@ -283,4 +287,3 @@ pnpm format
 ## License
 
 MIT License - see LICENSE file for details.
-


### PR DESCRIPTION
This PR adds a badge for the [Google Cloud MCP Server](https://glama.ai/mcp/servers/@andyl25/googlecloud-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@andyl25/googlecloud-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@andyl25/googlecloud-mcp/badge" alt="Google Cloud Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.